### PR TITLE
Don't hardcode ~/.emacs.d

### DIFF
--- a/autobookmarks.el
+++ b/autobookmarks.el
@@ -35,7 +35,7 @@
   :group 'files
   :prefix "abm-")
 
-(defcustom abm-file "~/.emacs.d/autobookmarks"
+(defcustom abm-file (locate-user-emacs-file "autobookmarks")
   "File where the bookmark data is persisted."
   :type 'file
   :group 'autobookmarks)


### PR DESCRIPTION
Use locate-user-emacs-file instead.

By the way, why exactly is this package better than recentf?  And you should probably use `read` instead of `load-file` to store your bookmark list…
